### PR TITLE
Update marius851000’s email

### DIFF
--- a/voters.json
+++ b/voters.json
@@ -650,7 +650,7 @@
   "contact@eliandoran.me": 21236836,
   "las@protonmail.ch": 22075344,
   "azat@bahawi.net": 22211000,
-  "mariusdavid@laposte.net": 22586596,
+  "marius@mariusdavid.fr": 22586596,
   "infinidoge@inx.moe": 22727114,
   "edmund.wu@protonmail.com": 22758444,
   "lhongxu@outlook.com": 22803888,


### PR DESCRIPTION
I have no longer access to my laposte.net mail account (due to some of their questionable practice). I’ll eventually make sure to update the one in maintainers.nix, next time I make a PR (and think about it).